### PR TITLE
Stop returning `Value` from `Session`. Return good old scale encoded values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "contract-transcode",
  "frame-support",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "drink-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ homepage = "https://github.com/Cardinal-Cryptography/drink"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Cardinal-Cryptography/drink"
-version = "0.1.6"
+version = "0.1.7"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.71" }
@@ -48,4 +48,4 @@ sp-runtime-interface = { version = "18.0.0" }
 
 # Local dependencies
 
-drink = { version = "0.1.6", path = "drink" }
+drink = { version = "0.1.7", path = "drink" }

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -364,7 +364,7 @@ impl<R: Runtime> Session<R> {
         self.call_returns.last().cloned()
     }
 
-    /// Returns the last value (in the encoded form) returned from calling a contract.
+    /// Returns the last value (in the decoded form) returned from calling a contract.
     ///
     /// Returns `None` if there has been no call yet, or if decoding failed.
     pub fn last_call_return<T: Decode>(&self) -> Option<MessageResult<T>> {

--- a/drink/src/session.rs
+++ b/drink/src/session.rs
@@ -67,9 +67,11 @@ pub enum SessionError {
     parity_scale_codec::Encode,
     parity_scale_codec::Decode,
     scale_info::TypeInfo,
+    Error,
 )]
 pub enum LangError {
     /// Failed to read execution input for the dispatchable.
+    #[error("Failed to read execution input for the dispatchable.")]
     CouldNotReadInput = 1u32,
 }
 

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -36,11 +36,9 @@ mod tests {
 
     use drink::{
         runtime::MinimalRuntime,
-        session::{
-            contract_transcode::{ContractMessageTranscoder, Tuple, Value},
-            Session,
-        },
+        session::{contract_transcode::ContractMessageTranscoder, Session},
     };
+    use scale::Decode;
 
     fn transcoder() -> Option<Rc<ContractMessageTranscoder>> {
         Some(Rc::new(
@@ -53,10 +51,6 @@ mod tests {
         fs::read("./target/ink/flipper.wasm").expect("Failed to find or read contract file")
     }
 
-    fn ok(v: Value) -> Value {
-        Value::Tuple(Tuple::new(Some("Ok"), vec![v]))
-    }
-
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
         let init_value = Session::<MinimalRuntime>::new(transcoder())?
@@ -64,8 +58,10 @@ mod tests {
             .call_and("get", &[])?
             .last_call_return()
             .expect("Call was successful");
+        let init_value =
+            Result::<bool, ()>::decode(&mut init_value.as_slice()).expect("Failed to decode bool");
 
-        assert_eq!(init_value, ok(Value::Bool(true)));
+        assert_eq!(init_value, Ok(true));
 
         Ok(())
     }
@@ -80,8 +76,10 @@ mod tests {
             .call_and("get", &[])?
             .last_call_return()
             .expect("Call was successful");
+        let init_value =
+            Result::<bool, ()>::decode(&mut init_value.as_slice()).expect("Failed to decode bool");
 
-        assert_eq!(init_value, ok(Value::Bool(false)));
+        assert_eq!(init_value, Ok(false));
 
         Ok(())
     }

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -38,7 +38,6 @@ mod tests {
         runtime::MinimalRuntime,
         session::{contract_transcode::ContractMessageTranscoder, Session},
     };
-    use scale::Decode;
 
     fn transcoder() -> Option<Rc<ContractMessageTranscoder>> {
         Some(Rc::new(
@@ -53,33 +52,31 @@ mod tests {
 
     #[test]
     fn initialization() -> Result<(), Box<dyn Error>> {
-        let init_value = Session::<MinimalRuntime>::new(transcoder())?
+        let init_value: bool = Session::<MinimalRuntime>::new(transcoder())?
             .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
             .call_and("get", &[])?
             .last_call_return()
+            .expect("Call was successful, so there should be a return")
             .expect("Call was successful");
-        let init_value =
-            Result::<bool, ()>::decode(&mut init_value.as_slice()).expect("Failed to decode bool");
 
-        assert_eq!(init_value, Ok(true));
+        assert_eq!(init_value, true);
 
         Ok(())
     }
 
     #[test]
     fn flipping() -> Result<(), Box<dyn Error>> {
-        let init_value = Session::<MinimalRuntime>::new(transcoder())?
+        let init_value: bool = Session::<MinimalRuntime>::new(transcoder())?
             .deploy_and(bytes(), "new", &["true".to_string()], vec![])?
             .call_and("flip", &[])?
             .call_and("flip", &[])?
             .call_and("flip", &[])?
             .call_and("get", &[])?
             .last_call_return()
+            .expect("Call was successful, so there should be a return")
             .expect("Call was successful");
-        let init_value =
-            Result::<bool, ()>::decode(&mut init_value.as_slice()).expect("Failed to decode bool");
 
-        assert_eq!(init_value, Ok(false));
+        assert_eq!(init_value, false);
 
         Ok(())
     }


### PR DESCRIPTION
`Value` is an awful thing to return. Hard to create, obscure, bleh. Go with encoded bytes.