### PR TITLE
doc: fix 404 URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Just use corresponding argument in the test macro:
 ```
 to your test function and you have just switched from E2E testcase to quasi-E2E one, that doesn't use any running node in the background!
 
-For a full example check out [ink! repository](https://github.com/paritytech/ink/blob/master/integration-tests/e2e-runtime-only-backend/lib.rs).
+For a full example check out [ink! repository](https://github.com/use-ink/ink/blob/master/integration-tests/internal/e2e-runtime-only-backend/lib.rs).
 
 ## With a command line tool
 


### PR DESCRIPTION
The link has expired, replace it with the latest address.