### PR TITLE
typo/fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,4 +117,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `NO_SALT`, `NO_ENDOWMENT` contstants added
+- `NO_SALT`, `NO_ENDOWMENT` constants added


### PR DESCRIPTION
Description
This pull request resolves a typographical error, replacing the incorrect term "contstants" with the correct "constants" in the Markdown file. Maintaining accurate documentation improves clarity and usability.

Changes Made
Replaced "contstants" with "constants".